### PR TITLE
fix(init): not init eks values when using gke

### DIFF
--- a/apis/castai/v1alpha1/zz_nodeconfiguration_terraformed.go
+++ b/apis/castai/v1alpha1/zz_nodeconfiguration_terraformed.go
@@ -122,6 +122,7 @@ func (tr *NodeConfiguration) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("Eks"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/config/nodeconfiguration/config.go
+++ b/config/nodeconfiguration/config.go
@@ -14,5 +14,8 @@ func Configure(p *config.Provider) {
 				Type: "github.com/crossplane-contrib/crossplane-provider-castai/apis/castai/v1alpha1.EksClusterId",
 			},
 		}
+		r.LateInitializer = config.LateInitializer{
+			IgnoredFields: []string{"eks"},
+		}
 	})
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes the following issue:

```
kubectl describe NodeConfiguration
Name:         configuration-gcp-gke-castai-7mmzk
Namespace:    
Labels:       cast-ai-cluster=configuration-gcp-gke-castai-s4knl
              crossplane.io/claim-name=
              crossplane.io/claim-namespace=
              crossplane.io/composite=configuration-gcp-gke-castai
Annotations:  crossplane.io/composition-resource-name: cluster-node-configuration
              crossplane.io/external-create-pending: 2024-05-05T11:41:59Z
              crossplane.io/external-create-succeeded: 2024-05-05T11:41:59Z
              crossplane.io/external-name: 1dae8365-d9cd-4c3f-8525-ec88c62c9123
              upjet.crossplane.io/provider-meta:
                {"e2bfb730-ecaa-11e6-8f88-34363bc7c4c0":{"create":60000000000,"delete":60000000000,"read":60000000000,"update":60000000000}}
API Version:  castai.upbound.io/v1alpha1
Kind:         NodeConfiguration
Metadata:
  Creation Timestamp:  2024-05-05T11:41:58Z
  Finalizers:
    finalizer.managedresource.crossplane.io
  Generate Name:  configuration-gcp-gke-castai-
  Generation:     5
  Owner References:
    API Version:           castai.gcp.platform.upbound.io/v1alpha1
    Block Owner Deletion:  true
    Controller:            true
    Kind:                  XFullAccess
    Name:                  configuration-gcp-gke-castai
    UID:                   3011a261-43cd-471c-a4f9-3e9e2abef1e2
  Resource Version:        47608
  UID:                     83577e44-74b0-45d2-bd78-bd35880bf875
Spec:
  Deletion Policy:  Delete
  For Provider:
    Cluster Id:      349cbd19-2f00-4758-9683-50ac2c007bcf
    Disk Cpu Ratio:  0
    Eks:
      Instance Profile Arn:  
      Security Groups:
    Min Disk Size:  100
    Name:           configuration-gcp-gke-castai-s4knl
    Subnets:
      projects/crossplane-playground/regions/us-west2/subnetworks/configuration-gcp-gke-castai-xtdwc
  Init Provider:
  Management Policies:
    *
  Provider Config Ref:
    Name:  default
Status:
  At Provider:
    Cluster Id:         349cbd19-2f00-4758-9683-50ac2c007bcf
    Container Runtime:  
    Disk Cpu Ratio:     0
    Eks:
      Dns Cluster Ip:        
      Imds Hop Limit:        0
      imdsV1:                false
      Instance Profile Arn:  
      Key Pair Id:           
      Volume Iops:           0
      Volume Kms Key Arn:    
      Volume Throughput:     0
      Volume Type:           
    Id:                      1dae8365-d9cd-4c3f-8525-ec88c62c9123
    Image:                   
    Init Script:             
    Min Disk Size:           100
    Name:                    configuration-gcp-gke-castai-s4knl
    Ssh Public Key:          
    Subnets:
      projects/crossplane-playground/regions/us-west2/subnetworks/configuration-gcp-gke-castai-xtdwc
  Conditions:
    Last Transition Time:  2024-05-05T11:44:09Z
    Reason:                Available
    Status:                True
    Type:                  Ready
    Last Transition Time:  2024-05-05T11:44:10Z
    Message:               observe failed: cannot run refresh: refresh failed: Missing required argument: The argument "security_groups" is required, but no definition was found.
    Reason:                ReconcileError
    Status:                False
    Type:                  Synced
    Last Transition Time:  2024-05-05T11:42:01Z
    Reason:                Finished
    Status:                True
    Type:                  AsyncOperation
    Last Transition Time:  2024-05-05T11:42:01Z
    Reason:                Success
    Status:                True
    Type:                  LastAsyncOperation
Events:
  Type     Reason                         Age                   From                                                        Message
  ----     ------                         ----                  ----                                                        -------
  Normal   CreatedExternalResource        8m59s                 managed/castai.upbound.io/v1alpha1, kind=nodeconfiguration  Successfully requested creation of external resource
  Warning  CannotObserveExternalResource  43s (x20 over 8m56s)  managed/castai.upbound.io/v1alpha1, kind=nodeconfiguration  cannot run refresh: refresh failed: Missing required argument: The argument "security_groups" is required, but no definition was found.
```

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
